### PR TITLE
cflags passthrough/v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "suricata-lua-sys"
 description = "Vendored Lua for Suricata"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 edition = "2021"
 rust-version = "1.56.0"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "suricata-lua-sys"
 description = "Vendored Lua for Suricata"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 edition = "2021"
 rust-version = "1.56.0"
 license = "MIT"

--- a/build.rs
+++ b/build.rs
@@ -32,8 +32,12 @@ fn main() {
         command.arg("mingw");
     }
 
-    // Required for building into a shared library.
-    command.arg("MYCFLAGS=-fPIC");
+    // -fPIC is required for building into a shared library; also
+    // pass-through CFLAGS to MYCFLAGS.
+    command.arg(format!(
+        "MYCFLAGS=-fPIC {}",
+        env::var("CFLAGS").unwrap_or_default()
+    ));
 
     // Don't inherit parent MAKEFLAGS, they may not be suitable for
     // this build.
@@ -45,6 +49,7 @@ fn main() {
     }
 
     println!("cargo:rerun-if-env-changed=SURICATA_LUA_SYS_HEADER_DST");
+    println!("cargo:rerun-if-env-changed=CFLAGS");
 
     println!("cargo:rustc-link-lib=static=lua");
     println!("cargo:rustc-link-search=native={}", build_dir.display());

--- a/build.rs
+++ b/build.rs
@@ -33,10 +33,11 @@ fn main() {
     }
 
     // -fPIC is required for building into a shared library; also
-    // pass-through CFLAGS to MYCFLAGS.
+    // pass-through CFLAGS and SURICATA_LUA_SYS_CFLAGS to MYCFLAGS.
     command.arg(format!(
-        "MYCFLAGS=-fPIC {}",
-        env::var("CFLAGS").unwrap_or_default()
+        "MYCFLAGS=-fPIC {} {}",
+        env::var("CFLAGS").unwrap_or_default(),
+        env::var("SURICATA_LUA_SYS_CFLAGS").unwrap_or_default()
     ));
 
     // We only want the libary, not the tool.
@@ -52,6 +53,7 @@ fn main() {
     }
 
     println!("cargo:rerun-if-env-changed=SURICATA_LUA_SYS_HEADER_DST");
+    println!("cargo:rerun-if-env-changed=SURICATA_LUA_SYS_CFLAGS");
     println!("cargo:rerun-if-env-changed=CFLAGS");
 
     println!("cargo:rustc-link-lib=static=lua");

--- a/build.rs
+++ b/build.rs
@@ -40,7 +40,7 @@ fn main() {
         env::var("SURICATA_LUA_SYS_CFLAGS").unwrap_or_default()
     ));
 
-    // We only want the libary, not the tool.
+    // We only want the library, not the tool.
     command.arg("a");
 
     // Don't inherit parent MAKEFLAGS, they may not be suitable for

--- a/build.rs
+++ b/build.rs
@@ -39,6 +39,9 @@ fn main() {
         env::var("CFLAGS").unwrap_or_default()
     ));
 
+    // We only want the libary, not the tool.
+    command.arg("a");
+
     // Don't inherit parent MAKEFLAGS, they may not be suitable for
     // this build.
     command.env_remove("MAKEFLAGS");


### PR DESCRIPTION
- **build.rs: pass through CFLAGS**
  

- **build.rs: only build the library not the tool**
  The tool is not required.
  

- **version: 0.1.0-alpha.7**
  